### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ $ brownie console
 2. Create variables for the Yearn Vault and Want Token addresses. These were obtained from the Yearn Registry. Also, loan the Yearn governance multisig.
 
 ```python
->>> vault = Vault.at("0xBFa4D8AA6d8a379aBFe7793399D3DdaCC5bBECBB")  # yvDAI (v0.2.2)
->>> token = Token.at("0x6b175474e89094c44da98b954eedeac495271d0f")  # DAI
+>>> vault = interface.VaultAPI("0xBFa4D8AA6d8a379aBFe7793399D3DdaCC5bBECBB")  # yvDAI (v0.2.2)
+>>> token = interface.IERC20("0x6b175474e89094c44da98b954eedeac495271d0f")  # DAI
 >>> gov = "ychad.eth"  # ENS for Yearn Governance Multisig
 ```
 


### PR DESCRIPTION
"Vault" and "Token" are not available when a beginner starts with the brownie strategy mix and loads console as in the README.
The interfaces are available and a beginner can interact with the contracts using the console loading it above.
If it were possible to make Token and Vault.at available, that would be even better, but I think one would need to include the Vault.vy contract etc into the repo...