### PR TITLE
fix: update method call typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ yearnvaults = project.load(Path.home() / ".brownie" / "packages" / config["depen
 Vault = yearnvaults.Vault
 Token = yearnvaults.Token
 vault = Vault.at("0xdA816459F1AB5631232FE5e97a05BBBb94970c95")
-token = Token("0x6b175474e89094c44da98b954eedeac495271d0f")
+token = Token.at("0x6b175474e89094c44da98b954eedeac495271d0f")
 gov = "ychad.eth"  # ENS for Yearn Governance Multisig
 ```
 Or we can access them by using the ABI (the jsons you find under build):


### PR DESCRIPTION
**Reference Issues/PRs**
Closes  https://github.com/yearn/brownie-strategy-mix/issues/73
Re-opened from: https://github.com/yearn/brownie-strategy-mix/pull/74
**What does this implement/fix? Explain your changes.**

Currently, the README has the following instruction:
```
from pathlib import Path
yearnvaults = project.load(Path.home() / ".brownie" / "packages" / "yearn/yearn-vaults@0.4.3")
Token = yearnvaults.Token
token = Token("0x6b175474e89094c44da98b954eedeac495271d0f")
```

When I run this, I see the error `TypeError: 'ContractContainer' object is not callable` because we are trying to call the `Token` object/constructor which is of type `>>> type(Token) <class 'brownie.network.contract.ContractContainer'>`.

We should really be calling the method `Token.at` like:

```
token = Token.at("0x6b175474e89094c44da98b954eedeac495271d0f")
```

