### PR TITLE
feat: Adding fn_isolation to snapshot chain for all tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,3 +88,10 @@ def strategy(strategist, keeper, vault, Strategy, gov):
 @pytest.fixture(scope="session")
 def RELATIVE_APPROX():
     yield 1e-5
+
+
+# Function scoped isolation fixture to enable xdist.
+# Snapshots the chain before each test and reverts after test completion.
+@pytest.fixture(scope="function", autouse=True)
+def shared_setup(fn_isolation):
+    pass


### PR DESCRIPTION
fn_isolation is an absolute game changer and should be used by default to speed up the tests and revert the chain to a safe state between tests. This is particularly useful when manipulating LP's within tests. 