### PR TITLE
chore: update docs on brownie's dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Alice can then redeem those shares using `Vault.withdrawAll()` for the correspon
 
 ## Installation and Setup
 
-1. [Install Brownie](https://eth-brownie.readthedocs.io/en/stable/install.html) & [Ganache-CLI](https://github.com/trufflesuite/ganache-cli), if you haven't already.
+1. [Install Brownie](https://eth-brownie.readthedocs.io/en/stable/install.html) & [Ganache](https://github.com/trufflesuite/ganache), if you haven't already. Make sure that the version of Ganache that you install is compatible with Brownie. You can check Brownie's Ganache dependency [here](https://eth-brownie.readthedocs.io/en/stable/install.html#dependencies).
 
 2. Sign up for [Infura](https://infura.io/) and generate an API key. Store it in the `WEB3_INFURA_PROJECT_ID` environment variable.
 


### PR DESCRIPTION
Fixes #81 

I have updated the README with the latest version of the ganache repository, as well as included a link to Brownie's  dependency list. It is currently out of date (claims it supports v6.12.2 instead of v7.0.2) but I have already submitted a PR to brownie to update the documentation. 

https://github.com/eth-brownie/brownie/pull/1448